### PR TITLE
Rename project from fabric to spool

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     "ISC",
+    "MPL-2.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",

--- a/tests/archive_tests.rs
+++ b/tests/archive_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Duration, Utc};
-use spool::context::SpoolContext;
 use serde_json::json;
+use spool::context::SpoolContext;
 use std::fs;
 use std::io::Write;
 use tempfile::TempDir;

--- a/tests/event_tests.rs
+++ b/tests/event_tests.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
-use spool::event::{Event, Operation};
 use serde_json::json;
+use spool::event::{Event, Operation};
 
 #[test]
 fn test_operation_serialization() {

--- a/tests/state_tests.rs
+++ b/tests/state_tests.rs
@@ -1,6 +1,6 @@
+use serde_json::json;
 use spool::context::SpoolContext;
 use spool::state::{Task, TaskStatus};
-use serde_json::json;
 use std::fs;
 use std::io::Write;
 use tempfile::TempDir;

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -1,5 +1,5 @@
-use spool::context::SpoolContext;
 use serde_json::json;
+use spool::context::SpoolContext;
 use std::fs;
 use std::io::Write;
 use tempfile::TempDir;


### PR DESCRIPTION
## Summary

- Rename package to `spool` (crate name `fabric` unavailable on crates.io)
- Rename `FabricContext` to `SpoolContext`
- Change `.fabric/` directory to `.spool/`
- Update CLI binary name, help text, and shell prompt
- Add CI hardening (cargo-deny, MSRV check, security audit)
- Add new CLI commands: `add`, `assign`, `claim`, `free`
- Add comprehensive test infrastructure
- Add documentation (README, CONTRIBUTING, getting-started)
- Clean up code style (remove section dividers)

The name "spool" maintains the textile metaphor - threads wind onto a spool, tasks collect in your project.

## Test plan

- [x] All 149 tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] CI checks pass