### PR TITLE
Add release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    echo "Usage: script/release [--major | --minor | --patch]"
+    echo ""
+    echo "Increments the version number, updates all references,"
+    echo "creates a git tag, GitHub release, and publishes to crates.io."
+    echo ""
+    echo "Options:"
+    echo "  --major    Bump major version (x.0.0)"
+    echo "  --minor    Bump minor version (0.x.0)"
+    echo "  --patch    Bump patch version (0.0.x)"
+    echo "  --dry-run  Show what would happen without making changes"
+    echo "  --help     Show this help message"
+    exit 1
+}
+
+log() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}warning:${NC} $1"
+}
+
+error() {
+    echo -e "${RED}error:${NC} $1" >&2
+    exit 1
+}
+
+# Parse arguments
+BUMP_TYPE=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --major) BUMP_TYPE="major"; shift ;;
+        --minor) BUMP_TYPE="minor"; shift ;;
+        --patch) BUMP_TYPE="patch"; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --help|-h) usage ;;
+        *) error "Unknown option: $1" ;;
+    esac
+done
+
+if [[ -z "$BUMP_TYPE" ]]; then
+    error "Must specify --major, --minor, or --patch"
+fi
+
+# Ensure we're in the repo root
+if [[ ! -f "Cargo.toml" ]]; then
+    error "Must run from repository root"
+fi
+
+# Ensure working directory is clean
+if [[ -n "$(git status --porcelain)" ]]; then
+    error "Working directory is not clean. Commit or stash changes first."
+fi
+
+# Ensure we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    error "Must be on main branch (currently on $CURRENT_BRANCH)"
+fi
+
+# Ensure main is up to date
+git fetch origin main
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [[ "$LOCAL" != "$REMOTE" ]]; then
+    error "Local main is not up to date with origin. Run 'git pull' first."
+fi
+
+# Get current version from Cargo.toml
+CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+if [[ -z "$CURRENT_VERSION" ]]; then
+    error "Could not read version from Cargo.toml"
+fi
+
+log "Current version: $CURRENT_VERSION"
+
+# Parse version components
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# Increment version
+case $BUMP_TYPE in
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    minor)
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    patch)
+        PATCH=$((PATCH + 1))
+        ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+log "New version: $NEW_VERSION"
+
+if $DRY_RUN; then
+    log "[dry-run] Would update Cargo.toml"
+    log "[dry-run] Would update src/shell.rs"
+    log "[dry-run] Would update Cargo.lock"
+    log "[dry-run] Would commit with message: Release v$NEW_VERSION"
+    log "[dry-run] Would create tag: v$NEW_VERSION"
+    log "[dry-run] Would push to origin"
+    log "[dry-run] Would create GitHub release"
+    log "[dry-run] Would publish to crates.io"
+    exit 0
+fi
+
+# Update Cargo.toml
+log "Updating Cargo.toml..."
+sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
+
+# Update shell.rs version string
+log "Updating src/shell.rs..."
+sed -i '' "s/spool shell v$CURRENT_VERSION/spool shell v$NEW_VERSION/" src/shell.rs
+
+# Update Cargo.lock
+log "Updating Cargo.lock..."
+cargo update --package spool
+
+# Run tests to make sure everything works
+log "Running tests..."
+cargo test --quiet
+
+# Run clippy
+log "Running clippy..."
+cargo clippy --quiet -- -D warnings
+
+# Commit changes
+log "Committing changes..."
+git add Cargo.toml Cargo.lock src/shell.rs
+git commit -m "Release v$NEW_VERSION"
+
+# Create tag
+log "Creating tag v$NEW_VERSION..."
+git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+
+# Push to origin
+log "Pushing to origin..."
+git push origin main
+git push origin "v$NEW_VERSION"
+
+# Create GitHub release
+log "Creating GitHub release..."
+gh release create "v$NEW_VERSION" \
+    --title "v$NEW_VERSION" \
+    --generate-notes
+
+# Publish to crates.io
+log "Publishing to crates.io..."
+echo ""
+warn "About to publish to crates.io. This cannot be undone."
+read -p "Continue? [y/N] " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cargo publish
+    log "Published to crates.io!"
+else
+    warn "Skipped crates.io publish. Run 'cargo publish' manually when ready."
+fi
+
+echo ""
+log "Release v$NEW_VERSION complete!"
+echo ""
+echo "  GitHub: https://github.com/iamnbutler/spool/releases/tag/v$NEW_VERSION"
+echo "  crates.io: https://crates.io/crates/spool"


### PR DESCRIPTION
## Summary

Adds `script/release` for automating releases.

```
Usage: script/release [--major | --minor | --patch]

Options:
  --major    Bump major version (x.0.0)
  --minor    Bump minor version (0.x.0)
  --patch    Bump patch version (0.0.x)
  --dry-run  Show what would happen without making changes
```

The script:
1. Validates working directory is clean and on main
2. Increments version in Cargo.toml and src/shell.rs
3. Updates Cargo.lock
4. Runs tests and clippy
5. Commits and tags
6. Pushes to origin
7. Creates GitHub release with auto-generated notes
8. Prompts before publishing to crates.io

## Test plan

- [x] `script/release --help` works
- [x] Script is executable