### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Git-native, event-sourced task management"

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -532,7 +532,7 @@ pub fn run_shell(ctx: SpoolContext) -> Result<()> {
 
     let _ = rl.load_history(&history_path);
 
-    println!("spool shell v0.1.0");
+    println!("spool shell v0.2.0");
     println!("Type 'help' for available commands, 'quit' to exit.\n");
 
     loop {


### PR DESCRIPTION
## Release v0.2.0

Bumps version from 0.1.0 to 0.2.0.

### Changes
- Updated version in Cargo.toml
- Updated version in src/shell.rs
- Updated Cargo.lock

### After merge
Run `script/release-tag 0.2.0` to:
- Create git tag v0.2.0
- Create GitHub release
- Publish to crates.io