### PR TITLE
Remove lint suppressions by refactoring to named structs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use crate::state::{load_or_materialize_state, Task, TaskStatus};
 use crate::writer::{
     assign_task as write_assign, complete_task as write_complete, create_task as write_create,
     get_current_branch, get_current_user, reopen_task as write_reopen, update_task as write_update,
+    CreateTaskParams,
 };
 
 #[derive(Parser)]
@@ -408,12 +409,14 @@ pub fn add_task(
 
     let id = write_create(
         ctx,
-        title,
-        description,
-        priority,
-        assignee,
-        tags,
-        stream,
+        CreateTaskParams {
+            title,
+            description,
+            priority,
+            assignee,
+            tags,
+            stream,
+        },
         &user,
         &branch,
     )?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,6 +7,17 @@ use crate::context::SpoolContext;
 use crate::event::{Event, Operation};
 use crate::id::generate_id;
 
+/// Parameters for creating a new task
+#[derive(Default)]
+pub struct CreateTaskParams<'a> {
+    pub title: &'a str,
+    pub description: Option<&'a str>,
+    pub priority: Option<&'a str>,
+    pub assignee: Option<&'a str>,
+    pub tags: Vec<String>,
+    pub stream: Option<&'a str>,
+}
+
 /// Write an event to the current day's event file
 pub fn write_event(ctx: &SpoolContext, event: &Event) -> Result<()> {
     let today = Utc::now().format("%Y-%m-%d").to_string();
@@ -26,38 +37,37 @@ pub fn write_event(ctx: &SpoolContext, event: &Event) -> Result<()> {
 }
 
 /// Create a new task and return its ID
-#[allow(clippy::too_many_arguments)]
 pub fn create_task(
     ctx: &SpoolContext,
-    title: &str,
-    description: Option<&str>,
-    priority: Option<&str>,
-    assignee: Option<&str>,
-    tags: Vec<String>,
-    stream: Option<&str>,
+    params: CreateTaskParams,
     by: &str,
     branch: &str,
 ) -> Result<String> {
     let id = generate_id();
 
     let mut d = serde_json::json!({
-        "title": title,
+        "title": params.title,
     });
 
-    if let Some(desc) = description {
+    if let Some(desc) = params.description {
         d["description"] = serde_json::Value::String(desc.to_string());
     }
-    if let Some(p) = priority {
+    if let Some(p) = params.priority {
         d["priority"] = serde_json::Value::String(p.to_string());
     }
-    if let Some(a) = assignee {
+    if let Some(a) = params.assignee {
         d["assignee"] = serde_json::Value::String(a.to_string());
     }
-    if !tags.is_empty() {
-        d["tags"] =
-            serde_json::Value::Array(tags.into_iter().map(serde_json::Value::String).collect());
+    if !params.tags.is_empty() {
+        d["tags"] = serde_json::Value::Array(
+            params
+                .tags
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
     }
-    if let Some(s) = stream {
+    if let Some(s) = params.stream {
         d["stream"] = serde_json::Value::String(s.to_string());
     }
 

--- a/tests/writer_tests.rs
+++ b/tests/writer_tests.rs
@@ -5,7 +5,7 @@ use spool::context::SpoolContext;
 use spool::event::{Event, Operation};
 use spool::writer::{
     complete_task, create_task, get_current_branch, get_current_user, reopen_task, set_stream,
-    update_task, write_event,
+    update_task, write_event, CreateTaskParams,
 };
 
 fn setup_spool_dir(temp_dir: &TempDir) -> std::path::PathBuf {
@@ -96,12 +96,10 @@ fn test_create_task_returns_id() {
 
     let id = create_task(
         &ctx,
-        "Test task",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Test task",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
@@ -127,12 +125,14 @@ fn test_create_task_with_all_fields() {
 
     let id = create_task(
         &ctx,
-        "Full task",
-        Some("Task description"),
-        Some("p1"),
-        Some("@dev"),
-        vec!["bug".to_string(), "urgent".to_string()],
-        None,
+        CreateTaskParams {
+            title: "Full task",
+            description: Some("Task description"),
+            priority: Some("p1"),
+            assignee: Some("@dev"),
+            tags: vec!["bug".to_string(), "urgent".to_string()],
+            stream: None,
+        },
         "@tester",
         "feature-branch",
     )
@@ -304,36 +304,30 @@ fn test_create_task_generates_unique_ids() {
 
     let id1 = create_task(
         &ctx,
-        "Task 1",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Task 1",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
     .unwrap();
     let id2 = create_task(
         &ctx,
-        "Task 2",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Task 2",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
     .unwrap();
     let id3 = create_task(
         &ctx,
-        "Task 3",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Task 3",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
@@ -353,12 +347,10 @@ fn test_event_json_format() {
 
     create_task(
         &ctx,
-        "Test",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Test",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
@@ -388,12 +380,11 @@ fn test_create_task_with_stream() {
 
     let _id = create_task(
         &ctx,
-        "Task in stream",
-        None,
-        None,
-        None,
-        vec![],
-        Some("my-stream"),
+        CreateTaskParams {
+            title: "Task in stream",
+            stream: Some("my-stream"),
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
@@ -414,12 +405,10 @@ fn test_set_stream_writes_event() {
     // Create a task first
     let id = create_task(
         &ctx,
-        "Test task",
-        None,
-        None,
-        None,
-        vec![],
-        None,
+        CreateTaskParams {
+            title: "Test task",
+            ..Default::default()
+        },
         "@tester",
         "main",
     )
@@ -450,12 +439,11 @@ fn test_set_stream_to_none() {
 
     let id = create_task(
         &ctx,
-        "Test",
-        None,
-        None,
-        None,
-        vec![],
-        Some("old-stream"),
+        CreateTaskParams {
+            title: "Test",
+            stream: Some("old-stream"),
+            ..Default::default()
+        },
         "@tester",
         "main",
     )


### PR DESCRIPTION
## Summary
- Replace `parse_add_args` 6-tuple with `AddArgs` struct
- Replace `parse_list_args` 6-tuple with `ListArgs` struct
- Replace `build_index` internal 5-tuple with `TaskIndexBuilder` struct
- Replace `create_task` 9 parameters with `CreateTaskParams` struct

The only remaining `#[allow]` is `should_implement_trait` on `OutputFormat::from_str`, which is valid because it's infallible (returns `Self` not `Result`).

## Test plan
- [x] All 156 tests pass
- [x] Clippy passes with no warnings
- [x] `cargo fmt --check` passes