### PR TITLE
Add changelog and README updates for 0.2.0/0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Spool will be documented in this file.
 
+## [0.3.0] - 2026-01-19
+
+### Added
+- Repository field in Cargo.toml for crates.io linking
+
+### Changed
+- Refactored lint suppressions into proper named structs (`TaskIndexBuilder`, `AddArgs`, `ListArgs`)
+- Consolidated `scripts/` into `script/` directory
+- Renamed misleading `md5_hash()` to `simple_hash()` in concurrency module
+
+### Fixed
+- Removed duplicate `get_current_branch()` function (now imports from writer module)
+- Removed unused `_seen_ids` parameter from validation
+- Updated deprecated `actions-rs/toolchain` to `dtolnay/rust-toolchain` in CI
+- Added missing `SetStream` operation test coverage
+- Fixed benchmark Task creation to include `stream` field
+
+## [0.2.0] - 2026-01-18
+
+### Added
+- **Streams**: Group tasks into collections with `--stream` flag
+  - `spool add "Task" --stream my-stream` - Create task in a stream
+  - `spool list --stream my-stream` - Filter tasks by stream
+  - `set_stream` operation to move tasks between streams
+- **CLI commands** promoted from shell-only:
+  - `spool add` - Create tasks directly from CLI
+  - `spool assign <id> @user` - Assign task to a user
+  - `spool claim <id>` - Assign task to yourself
+  - `spool free <id>` - Unassign task
+- `CreateTaskParams` struct for cleaner task creation API
+
+### Changed
+- Shell now uses named argument structs instead of tuples
+
 ## [0.1.0] - 2026-01-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ spool show task-abc123
 spool assign task-abc123 @alice
 spool complete task-abc123
 
+# Group tasks with streams
+spool add "Backend work" --stream api
+spool list --stream api
+
 # Interactive mode
 spool shell
 ```


### PR DESCRIPTION
## Summary
- Add CHANGELOG entries for v0.2.0 and v0.3.0
- Document streams feature in README Quick Start

## Changes

### CHANGELOG.md
- **0.3.0**: Repository field, code quality refactoring, CI fixes
- **0.2.0**: Streams feature, CLI commands (add, assign, claim, free)

### README.md
- Added streams example to Quick Start section