### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Spool will be documented in this file.
 
+## [0.3.1] - 2026-01-19
+
+### Added
+- `spool stream <id> [name]` command to move tasks between streams
+- `--stream` flag on `spool update` command
+- Stream field displayed in `spool show` output
+- Shell: `stream` command and `--stream` flag on `update`
+
 ## [0.3.0] - 2026-01-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spool"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Git-native, event-sourced task management"

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -608,7 +608,7 @@ pub fn run_shell(ctx: SpoolContext) -> Result<()> {
 
     let _ = rl.load_history(&history_path);
 
-    println!("spool shell v0.3.0");
+    println!("spool shell v0.3.1");
     println!("Type 'help' for available commands, 'quit' to exit.\n");
 
     loop {


### PR DESCRIPTION
## Release v0.3.1

### Added
- `spool stream <id> [name]` command to move tasks between streams
- `--stream` flag on `spool update` command
- Stream field displayed in `spool show` output
- Shell: `stream` command and `--stream` flag on `update`

### After merge
```bash
script/release-tag 0.3.1
```