### PR TITLE
Update release scripts for workspace publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary: spool
           - os: macos-latest
             target: x86_64-apple-darwin
-            binary: spool
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary: spool
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,17 +34,28 @@ jobs:
       - name: Package
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          ARCHIVE="spool-${VERSION}-${{ matrix.target }}"
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/${{ matrix.binary }} dist/
+
+          # Package spool CLI
+          ARCHIVE_CLI="spool-${VERSION}-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/spool dist/
           cd dist
-          tar -czvf "${ARCHIVE}.tar.gz" ${{ matrix.binary }}
-          shasum -a 256 "${ARCHIVE}.tar.gz" > "${ARCHIVE}.tar.gz.sha256"
+          tar -czvf "${ARCHIVE_CLI}.tar.gz" spool
+          shasum -a 256 "${ARCHIVE_CLI}.tar.gz" > "${ARCHIVE_CLI}.tar.gz.sha256"
+          rm spool
+          cd ..
+
+          # Package spool-ui
+          ARCHIVE_UI="spool-ui-${VERSION}-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/spool-ui dist/
+          cd dist
+          tar -czvf "${ARCHIVE_UI}.tar.gz" spool-ui
+          shasum -a 256 "${ARCHIVE_UI}.tar.gz" > "${ARCHIVE_UI}.tar.gz.sha256"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: spool-${{ matrix.target }}
+          name: binaries-${{ matrix.target }}
           path: dist/*.tar.gz*
 
   create-release:

--- a/crates/spool-cli/Cargo.toml
+++ b/crates/spool-cli/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.70"
 description = "CLI for spool - git-native task management"
 license = "MIT"
 repository = "https://github.com/iamnbutler/spool"
+readme = "../../README.md"
+keywords = ["task", "git", "cli", "event-sourcing"]
+categories = ["development-tools", "command-line-utilities"]
 
 [[bin]]
 name = "spool"

--- a/crates/spool-ui/Cargo.toml
+++ b/crates/spool-ui/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.70"
 description = "TUI for spool - git-native task management"
 license = "MIT"
 repository = "https://github.com/iamnbutler/spool"
+readme = "README.md"
+keywords = ["task", "git", "tui", "terminal"]
+categories = ["development-tools", "command-line-utilities"]
 
 [[bin]]
 name = "spool-ui"

--- a/crates/spool-ui/README.md
+++ b/crates/spool-ui/README.md
@@ -1,0 +1,46 @@
+# spool-ui
+
+Terminal UI for [spool](https://crates.io/crates/spool) - git-native task management.
+
+```bash
+cargo install spool-ui
+```
+
+## Usage
+
+Run in a spool-initialized directory:
+
+```bash
+spool-ui
+```
+
+## Keybindings
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate tasks (or scroll detail when focused) |
+| `g` / `G` | First / last task |
+| `Enter` | Toggle detail panel |
+| `Tab` | Switch focus (list/detail) |
+| `c` | Complete task |
+| `r` | Reopen task |
+| `n` | New task |
+| `v` | Cycle view (Open/Complete/All) |
+| `s` | Cycle sort (Priority/Created/Title) |
+| `S` | Cycle stream filter |
+| `/` | Search |
+| `q` | Quit |
+
+## Features
+
+- Task list with priority coloring and status markers
+- Detail panel with full task info and event history
+- Status filtering (open/complete/all)
+- Sorting (priority/created/title)
+- Search (title, description, tags)
+- Stream navigation
+- Inline task creation and completion
+
+## License
+
+MIT

--- a/crates/spool/Cargo.toml
+++ b/crates/spool/Cargo.toml
@@ -6,8 +6,9 @@ rust-version = "1.70"
 description = "Git-native, event-sourced task management"
 license = "MIT"
 repository = "https://github.com/iamnbutler/spool"
-keywords = ["task", "git", "event-sourcing"]
-categories = ["development-tools"]
+readme = "../../README.md"
+keywords = ["task", "git", "event-sourcing", "cli"]
+categories = ["development-tools", "command-line-utilities"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/script/release
+++ b/script/release
@@ -56,7 +56,8 @@ LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
 [[ "$LOCAL" != "$REMOTE" ]] && error "Local main is not up to date with origin. Run 'git pull' first."
 
-CURRENT_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+# Read version from workspace.package
+CURRENT_VERSION=$(grep -A5 '\[workspace.package\]' Cargo.toml | grep '^version = ' | sed 's/version = "\(.*\)"/\1/')
 [[ -z "$CURRENT_VERSION" ]] && error "Could not read version from Cargo.toml"
 
 log "Current version: $CURRENT_VERSION"
@@ -76,11 +77,11 @@ log "New version: $NEW_VERSION"
 
 if $DRY_RUN; then
     log "[dry-run] Would create branch: $RELEASE_BRANCH"
-    log "[dry-run] Would update Cargo.toml, src/shell.rs, Cargo.lock"
+    log "[dry-run] Would update Cargo.toml (workspace + crates)"
     log "[dry-run] Would create PR for release"
     log "[dry-run] After PR merge, would tag v$NEW_VERSION"
     log "[dry-run] Would create GitHub release"
-    log "[dry-run] Would publish to crates.io"
+    log "[dry-run] Would publish spool, spool-cli, spool-ui to crates.io"
     exit 0
 fi
 
@@ -88,26 +89,29 @@ fi
 log "Creating release branch..."
 git checkout -b "$RELEASE_BRANCH"
 
-# Update versions
-log "Updating Cargo.toml..."
+# Update workspace version
+log "Updating workspace Cargo.toml..."
 sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" Cargo.toml
 
-log "Updating src/shell.rs..."
-sed -i '' "s/spool shell v$CURRENT_VERSION/spool shell v$NEW_VERSION/" src/shell.rs
+# Update individual crate versions
+log "Updating crate versions..."
+for crate_toml in crates/*/Cargo.toml; do
+    sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" "$crate_toml"
+done
 
 log "Updating Cargo.lock..."
-cargo update --package spool --quiet
+cargo update --workspace --quiet
 
 # Run tests
 log "Running tests..."
-cargo test --quiet
+cargo test --workspace --quiet
 
 log "Running clippy..."
-cargo clippy --quiet -- -D warnings
+cargo clippy --workspace --quiet -- -D warnings
 
 # Commit and push
 log "Committing changes..."
-git add Cargo.toml Cargo.lock src/shell.rs
+git add Cargo.toml Cargo.lock crates/*/Cargo.toml
 git commit -m "Release v$NEW_VERSION"
 
 log "Pushing release branch..."
@@ -122,15 +126,20 @@ PR_URL=$(gh pr create \
 Bumps version from $CURRENT_VERSION to $NEW_VERSION.
 
 ### Changes
-- Updated version in Cargo.toml
-- Updated version in src/shell.rs
+- Updated workspace version in Cargo.toml
+- Updated versions in all crates
 - Updated Cargo.lock
+
+### Crates to publish
+1. \`spool\` - core library
+2. \`spool-cli\` - CLI binary
+3. \`spool-ui\` - TUI binary
 
 ### After merge
 Run \`script/release-tag $NEW_VERSION\` to:
 - Create git tag v$NEW_VERSION
 - Create GitHub release
-- Publish to crates.io" \
+- Publish all crates to crates.io" \
     --head "$RELEASE_BRANCH" \
     --base main)
 

--- a/script/release-tag
+++ b/script/release-tag
@@ -13,7 +13,7 @@ usage() {
     echo "Run this after the release PR has been merged."
     echo ""
     echo "Example:"
-    echo "  script/release-tag 0.2.0"
+    echo "  script/release-tag 0.5.0"
     exit 1
 }
 
@@ -38,8 +38,8 @@ CURRENT_BRANCH=$(git branch --show-current)
 git fetch origin main
 git reset --hard origin/main
 
-# Verify version in Cargo.toml matches
-CARGO_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+# Verify version in workspace Cargo.toml matches
+CARGO_VERSION=$(grep -A5 '\[workspace.package\]' Cargo.toml | grep '^version = ' | sed 's/version = "\(.*\)"/\1/')
 if [[ "$CARGO_VERSION" != "$VERSION" ]]; then
     error "Version mismatch: Cargo.toml has $CARGO_VERSION, expected $VERSION"
 fi
@@ -57,19 +57,39 @@ gh release create "v$VERSION" \
 
 log "Publishing to crates.io..."
 echo ""
-warn "About to publish to crates.io. This cannot be undone."
+warn "About to publish all crates to crates.io. This cannot be undone."
+warn "Publishing order: spool -> spool-cli -> spool-ui"
 read -p "Continue? [y/N] " -n 1 -r
 echo ""
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-    cargo publish
-    log "Published to crates.io!"
+    log "Publishing spool..."
+    cargo publish --package spool
+
+    # Wait for crates.io to index the new version
+    log "Waiting for crates.io to index spool..."
+    sleep 30
+
+    log "Publishing spool-cli..."
+    cargo publish --package spool-cli
+
+    log "Publishing spool-ui..."
+    cargo publish --package spool-ui
+
+    log "Published all crates to crates.io!"
 else
-    warn "Skipped crates.io publish. Run 'cargo publish' manually when ready."
+    warn "Skipped crates.io publish. Run manually in order:"
+    echo "  cargo publish --package spool"
+    echo "  sleep 30"
+    echo "  cargo publish --package spool-cli"
+    echo "  cargo publish --package spool-ui"
 fi
 
 echo ""
 log "Release v$VERSION complete!"
 echo ""
 echo "  GitHub: https://github.com/iamnbutler/spool/releases/tag/v$VERSION"
-echo "  crates.io: https://crates.io/crates/spool"
+echo "  crates.io:"
+echo "    - https://crates.io/crates/spool"
+echo "    - https://crates.io/crates/spool-cli"
+echo "    - https://crates.io/crates/spool-ui"


### PR DESCRIPTION
## Summary
Updates release infrastructure for the workspace structure with multiple crates.

## Cargo.toml changes
- `spool`: readme points to root README.md, added keywords/categories
- `spool-cli`: readme points to root README.md, added keywords/categories  
- `spool-ui`: has its own README.md, added keywords/categories

## New file
- `crates/spool-ui/README.md` - standalone docs for the TUI

## Release scripts
- `script/release` - handles workspace versioning (updates root + all crates)
- `script/release-tag` - publishes in order: spool → spool-cli → spool-ui (with 30s wait for crates.io indexing)
- `.github/workflows/release.yml` - builds and packages both `spool` and `spool-ui` binaries

## Test plan
- [x] Build passes
- [ ] Test release script with `--dry-run`