### PR TITLE
Release v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spool"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "spool-cli"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "spool-ui"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 license = "MIT"

--- a/crates/spool-cli/Cargo.toml
+++ b/crates/spool-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool-cli"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "CLI for spool - git-native task management"

--- a/crates/spool-ui/Cargo.toml
+++ b/crates/spool-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool-ui"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "TUI for spool - git-native task management"

--- a/crates/spool/Cargo.toml
+++ b/crates/spool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spool"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "Git-native, event-sourced task management"


### PR DESCRIPTION
## Release v1.0.0

Bumps version from 0.4.0 to 1.0.0.

### Changes
- Updated workspace version in Cargo.toml
- Updated versions in all crates
- Updated Cargo.lock

### Crates to publish
1. `spool` - core library
2. `spool-cli` - CLI binary
3. `spool-ui` - TUI binary

### After merge
Run `script/release-tag 1.0.0` to:
- Create git tag v1.0.0
- Create GitHub release
- Publish all crates to crates.io