### PR TITLE
Add version to spool dependency + update docs for v1.0.0

### DIFF
--- a/crates/spool-cli/Cargo.toml
+++ b/crates/spool-cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "spool"
 path = "src/main.rs"
 
 [dependencies]
-spool = { path = "../spool" }
+spool = { version = "1.0.0", path = "../spool" }
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 

--- a/crates/spool-ui/Cargo.toml
+++ b/crates/spool-ui/Cargo.toml
@@ -15,7 +15,7 @@ name = "spool-ui"
 path = "src/main.rs"
 
 [dependencies]
-spool = { path = "../spool" }
+spool = { version = "1.0.0", path = "../spool" }
 anyhow = "1.0"
 ratatui = "0.29"
 crossterm = "0.28"


### PR DESCRIPTION
## Changes
1. Add version to spool dependency in spool-cli and spool-ui Cargo.toml (required for crates.io publishing)
2. Update docs for v1.0.0 release:
   - README.md: Add TUI section and update install commands
   - CHANGELOG.md: Add 1.0.0 release notes
   - skills/spool.md: Add TUI info, remove shell references

## After merge
```bash
cargo publish --package spool-cli
cargo publish --package spool-ui
```