### PR TITLE
TUI: Auto-init and command palette

### DIFF
--- a/crates/spool-ui/src/main.rs
+++ b/crates/spool-ui/src/main.rs
@@ -100,6 +100,28 @@ fn run_app<B: ratatui::backend::Backend>(terminal: &mut Terminal<B>, mut app: Ap
                     continue;
                 }
 
+                // Command palette handling
+                if app.show_command_palette {
+                    match key.code {
+                        KeyCode::Esc => app.show_command_palette = false,
+                        KeyCode::Char('j') | KeyCode::Down => app.command_next(),
+                        KeyCode::Char('k') | KeyCode::Up => app.command_previous(),
+                        KeyCode::Enter => app.execute_selected_command(),
+                        KeyCode::Char(':') => app.show_command_palette = false,
+                        _ => {}
+                    }
+                    continue;
+                }
+
+                // Command palette toggle (: like vim)
+                if key.code == KeyCode::Char(':')
+                    && app.input_mode == InputMode::Normal
+                    && !app.search_mode
+                {
+                    app.toggle_command_palette();
+                    continue;
+                }
+
                 match app.input_mode {
                     InputMode::NewTask => match key.code {
                         KeyCode::Esc => app.cancel_input(),


### PR DESCRIPTION
## Summary

Two improvements to the TUI:

### Auto-init
- `spool-ui` now automatically initializes `.spool/` directory if not found
- No need to run `spool init` separately before using the TUI

### Command Palette
Access system commands via `:` (vim-style):
- **Rebuild cache** - Regenerate state from events
- **Validate events** - Check event file integrity
- **Archive old tasks** - Archive completed tasks older than 30 days

## Test plan
- [ ] Run `spool-ui` in a directory without `.spool/` - should auto-init
- [ ] Press `:` to open command palette
- [ ] Test each command (rebuild, validate, archive)
- [ ] Verify `?` help shows `:` command