### PR TITLE
feat(spool-cli): add stream prune command to clean up empty streams

### DIFF
--- a/crates/spool-cli/src/main.rs
+++ b/crates/spool-cli/src/main.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 use spool::archive::archive_tasks;
 use spool::cli::{
     add_stream, add_task, assign_task, claim_task, complete_task, delete_stream, free_task,
-    list_streams, list_tasks, reopen_task, show_stream, show_task, update_stream_cmd, update_task,
-    Cli, Commands, OutputFormat, StreamCommands,
+    list_streams, list_tasks, prune_streams, reopen_task, show_stream, show_task,
+    update_stream_cmd, update_task, Cli, Commands, OutputFormat, StreamCommands,
 };
 use spool::context::{init, SpoolContext};
 use spool::state::rebuild;
@@ -133,6 +133,7 @@ fn main() -> Result<()> {
                     description,
                 } => update_stream_cmd(&ctx, &id, name.as_deref(), description.as_deref()),
                 StreamCommands::Delete { id } => delete_stream(&ctx, &id),
+                StreamCommands::Prune { force } => prune_streams(&ctx, force),
             }
         }
     }

--- a/crates/spool/src/cli.rs
+++ b/crates/spool/src/cli.rs
@@ -191,6 +191,12 @@ pub enum StreamCommands {
         /// Stream ID
         id: String,
     },
+    /// Prune streams with 0 open tasks
+    Prune {
+        /// Actually delete the streams (default: dry-run listing)
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -821,6 +827,79 @@ pub fn set_task_stream(ctx: &SpoolContext, task_id: &str, stream_id: Option<&str
         Some(s) => println!("Moved task {} to stream {}", task_id, s),
         None => println!("Removed task {} from stream", task_id),
     }
+
+    Ok(())
+}
+
+/// Prune streams with 0 open tasks
+pub fn prune_streams(ctx: &SpoolContext, force: bool) -> Result<()> {
+    let state = load_or_materialize_state(ctx)?;
+
+    // Find streams with 0 open tasks
+    let mut pruneable: Vec<(&str, &str, usize)> = Vec::new();
+
+    for (stream_id, stream) in &state.streams {
+        let open_count = state
+            .tasks
+            .values()
+            .filter(|t| t.stream.as_deref() == Some(stream_id.as_str()))
+            .filter(|t| t.status == TaskStatus::Open)
+            .count();
+
+        if open_count == 0 {
+            let complete_count = state
+                .tasks
+                .values()
+                .filter(|t| t.stream.as_deref() == Some(stream_id.as_str()))
+                .filter(|t| t.status == TaskStatus::Complete)
+                .count();
+            pruneable.push((stream_id.as_str(), stream.name.as_str(), complete_count));
+        }
+    }
+
+    // Sort alphabetically by name for deterministic output
+    pruneable.sort_by(|a, b| a.1.cmp(b.1));
+
+    if pruneable.is_empty() {
+        println!("No streams with 0 open tasks found.");
+        return Ok(());
+    }
+
+    if !force {
+        // Dry-run: just list the streams
+        println!(
+            "{} stream(s) with 0 open tasks (run with --force to delete):",
+            pruneable.len()
+        );
+        for (id, name, complete_count) in &pruneable {
+            println!("  {} ({}) — {} completed task(s)", name, id, complete_count);
+        }
+        return Ok(());
+    }
+
+    // Actually prune the streams
+    let user = get_current_user()?;
+    let branch = get_current_branch()?;
+
+    for (stream_id, stream_name, _) in &pruneable {
+        // First, clear the stream from any completed tasks still assigned to it
+        let tasks_to_clear: Vec<String> = state
+            .tasks
+            .values()
+            .filter(|t| t.stream.as_deref() == Some(*stream_id))
+            .map(|t| t.id.clone())
+            .collect();
+
+        for task_id in tasks_to_clear {
+            write_stream(ctx, &task_id, None, &user, &branch)?;
+        }
+
+        // Then delete the stream
+        write_delete_stream(ctx, stream_id, &user, &branch)?;
+        println!("Pruned stream: {} ({})", stream_name, stream_id);
+    }
+
+    println!("Pruned {} stream(s).", pruneable.len());
 
     Ok(())
 }

--- a/crates/spool/tests/cli_tests.rs
+++ b/crates/spool/tests/cli_tests.rs
@@ -689,3 +689,33 @@ fn test_cli_parse_stream_delete() {
         panic!("Expected Stream command");
     }
 }
+
+#[test]
+fn test_cli_parse_stream_prune() {
+    let cli = Cli::parse_from(["spool", "stream", "prune"]);
+
+    if let Commands::Stream { command } = cli.command {
+        if let StreamCommands::Prune { force } = command {
+            assert!(!force);
+        } else {
+            panic!("Expected Stream Prune command");
+        }
+    } else {
+        panic!("Expected Stream command");
+    }
+}
+
+#[test]
+fn test_cli_parse_stream_prune_force() {
+    let cli = Cli::parse_from(["spool", "stream", "prune", "--force"]);
+
+    if let Commands::Stream { command } = cli.command {
+        if let StreamCommands::Prune { force } = command {
+            assert!(force);
+        } else {
+            panic!("Expected Stream Prune command");
+        }
+    } else {
+        panic!("Expected Stream command");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `spool stream prune` command to identify and remove streams with 0 open tasks
- Without `--force`: dry-run that lists pruneable streams with their completed task counts
- With `--force`: actually deletes the streams, clearing stream assignment from any completed tasks first

## Usage

```bash
# Dry-run: list streams that can be pruned
$ spool stream prune
2 stream(s) with 0 open tasks (run with --force to delete):
  old-project (abc123) — 4 completed task(s)
  scratch (def456) — 0 completed task(s)

# Actually delete the streams
$ spool stream prune --force
Pruned stream: old-project (abc123)
Pruned stream: scratch (def456)
Pruned 2 stream(s).
```

## Test plan

- [x] Added CLI parsing tests for `spool stream prune` and `spool stream prune --force`
- [x] All 264 workspace tests pass
- [x] Clippy passes with no warnings

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)