### PR TITLE
feat(cli,ui): clarify when task list is filtered

### DIFF
--- a/crates/spool-cli/tests/cli_integration_tests.rs
+++ b/crates/spool-cli/tests/cli_integration_tests.rs
@@ -945,3 +945,108 @@ fn test_stream_list_json_format() {
         .stdout(predicate::str::contains("\"name\":"))
         .stdout(predicate::str::contains("JSON Stream"));
 }
+
+#[test]
+fn test_list_filter_context_shows_stream_name() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_initialized_spool(&temp_dir);
+
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["stream", "add", "API"])
+        .assert()
+        .success();
+
+    let id_output = spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["stream", "list", "--format", "ids"])
+        .assert()
+        .success();
+    let stream_id = String::from_utf8_lossy(&id_output.get_output().stdout)
+        .trim()
+        .to_string();
+
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["add", "API task", "--stream", &stream_id])
+        .assert()
+        .success();
+
+    // Filter by stream name should show "Filtered by: stream: API"
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["list", "--stream-name", "API"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filtered by: stream: API"));
+}
+
+#[test]
+fn test_list_filter_context_shows_no_stream() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_initialized_spool(&temp_dir);
+
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["add", "Unassigned task"])
+        .assert()
+        .success();
+
+    // --no-stream should show "Filtered by: no stream"
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["list", "--no-stream"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filtered by: no stream"));
+}
+
+#[test]
+fn test_list_filter_context_shows_multiple_filters() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_initialized_spool(&temp_dir);
+
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["add", "High priority task", "--priority", "p0", "--tag", "urgent"])
+        .assert()
+        .success();
+
+    // Multiple filters should all be shown
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["list", "--priority", "p0", "--tag", "urgent"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filtered by:"))
+        .stdout(predicate::str::contains("priority: p0"))
+        .stdout(predicate::str::contains("tag: urgent"));
+}
+
+#[test]
+fn test_list_filter_context_omits_default_status() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_initialized_spool(&temp_dir);
+
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["add", "Simple task"])
+        .assert()
+        .success();
+
+    // Default (--status open) should not show filter context
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filtered by:").not());
+
+    // Explicit "complete" status should show filter context
+    spool_cmd()
+        .current_dir(temp_dir.path())
+        .args(["list", "--status", "complete"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filtered by: status: complete"));
+}

--- a/crates/spool-ui/src/ui.rs
+++ b/crates/spool-ui/src/ui.rs
@@ -195,6 +195,8 @@ fn draw_task_list(f: &mut Frame, area: Rect, app: &mut App) {
 
     let title = if app.search_mode {
         format!(" Tasks  /{}▌", app.search_query)
+    } else if app.stream_filter.is_some() {
+        format!(" Tasks in: {} ", app.stream_filter_label())
     } else {
         " Tasks ".to_string()
     };

--- a/crates/spool/src/cli.rs
+++ b/crates/spool/src/cli.rs
@@ -290,6 +290,50 @@ pub fn list_tasks(
             }
         }
         OutputFormat::Table => {
+            // Build filter context line
+            let mut filter_parts: Vec<String> = Vec::new();
+
+            // Stream filter (resolved to name if possible)
+            if let Some(ref stream_id) = effective_stream {
+                let stream_name = state
+                    .streams
+                    .get(stream_id)
+                    .map(|s| s.name.as_str())
+                    .unwrap_or(stream_id);
+                filter_parts.push(format!("stream: {}", stream_name));
+            }
+            if no_stream {
+                filter_parts.push("no stream".to_string());
+            }
+
+            // Status filter (omit "open" as it's the default)
+            if let Some(s) = status_filter {
+                if s != "open" {
+                    filter_parts.push(format!("status: {}", s));
+                }
+            }
+
+            // Priority filter
+            if let Some(p) = priority {
+                filter_parts.push(format!("priority: {}", p));
+            }
+
+            // Assignee filter
+            if let Some(a) = assignee {
+                filter_parts.push(format!("assignee: {}", a));
+            }
+
+            // Tag filter
+            if let Some(t) = tag {
+                filter_parts.push(format!("tag: {}", t));
+            }
+
+            // Print filter line if any filters are active
+            if !filter_parts.is_empty() {
+                println!("Filtered by: {}", filter_parts.join(", "));
+                println!();
+            }
+
             if tasks.is_empty() {
                 println!("No tasks found.");
                 return Ok(());


### PR DESCRIPTION
## Summary

- **CLI**: Add "Filtered by:" context line before the table when any filter is active (stream, status, priority, assignee, tag, no-stream)
- **TUI**: Show "Tasks in: <stream name>" in the task list panel title when a stream filter is active

This makes it much clearer when viewing a filtered list, especially when piping CLI output or at a glance in the TUI.

## Test plan

- [x] All existing tests pass
- [x] Added 4 new integration tests for CLI filter context display:
  - `test_list_filter_context_shows_stream_name`
  - `test_list_filter_context_shows_no_stream`
  - `test_list_filter_context_shows_multiple_filters`
  - `test_list_filter_context_omits_default_status`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)