### PR TITLE
fix(spool): normalize stream names to lowercase

### DIFF
--- a/crates/spool-cli/tests/cli_integration_tests.rs
+++ b/crates/spool-cli/tests/cli_integration_tests.rs
@@ -675,14 +675,14 @@ fn test_stream_add_and_list() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Created stream:"))
-        .stdout(predicate::str::contains("My Stream"));
+        .stdout(predicate::str::contains("my stream"));
 
     spool_cmd()
         .current_dir(temp_dir.path())
         .args(["stream", "list"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("My Stream"));
+        .stdout(predicate::str::contains("my stream"));
 }
 
 #[test]
@@ -702,7 +702,7 @@ fn test_stream_show_by_name() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Name:"))
-        .stdout(predicate::str::contains("Backend"))
+        .stdout(predicate::str::contains("backend"))
         .stdout(predicate::str::contains("Backend work"));
 }
 
@@ -751,7 +751,7 @@ fn test_stream_update() {
         .args(["stream", "show", "--name", "New Name"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("New Name"));
+        .stdout(predicate::str::contains("new name"));
 }
 
 #[test]
@@ -943,5 +943,5 @@ fn test_stream_list_json_format() {
         .assert()
         .success()
         .stdout(predicate::str::contains("\"name\":"))
-        .stdout(predicate::str::contains("JSON Stream"));
+        .stdout(predicate::str::contains("json stream"));
 }

--- a/crates/spool/src/cli.rs
+++ b/crates/spool/src/cli.rs
@@ -599,7 +599,7 @@ pub fn add_stream(ctx: &SpoolContext, name: &str, description: Option<&str>) -> 
     let branch = get_current_branch()?;
 
     let id = write_create_stream(ctx, name, description, &user, &branch)?;
-    println!("Created stream: {} ({})", name, id);
+    println!("Created stream: {} ({})", name.to_lowercase(), id);
 
     Ok(())
 }
@@ -679,7 +679,7 @@ pub fn show_stream(ctx: &SpoolContext, id: Option<&str>, name: Option<&str>) -> 
         (None, Some(name)) => state
             .streams
             .values()
-            .find(|s| s.name == name)
+            .find(|s| s.name.eq_ignore_ascii_case(name))
             .ok_or_else(|| anyhow!("Stream not found with name: {}", name))?,
         (None, None) => return Err(anyhow!("Either stream ID or --name must be provided")),
     };

--- a/crates/spool/src/state.rs
+++ b/crates/spool/src/state.rs
@@ -337,7 +337,7 @@ fn apply_event(
                     .get("name")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
-                    .to_string(),
+                    .to_lowercase(),
                 description: d
                     .get("description")
                     .and_then(|v| v.as_str())
@@ -351,7 +351,7 @@ fn apply_event(
             if let Some(stream) = streams.get_mut(&event.id) {
                 let d = &event.d;
                 if let Some(name) = d.get("name").and_then(|v| v.as_str()) {
-                    stream.name = name.to_string();
+                    stream.name = name.to_lowercase();
                 }
                 if let Some(desc) = d.get("description").and_then(|v| v.as_str()) {
                     stream.description = Some(desc.to_string());

--- a/crates/spool/src/writer.rs
+++ b/crates/spool/src/writer.rs
@@ -264,7 +264,7 @@ pub fn create_stream(
     let id = generate_id();
 
     let mut d = serde_json::json!({
-        "name": name,
+        "name": name.to_lowercase(),
     });
 
     if let Some(desc) = description {
@@ -298,7 +298,7 @@ pub fn update_stream(
     let mut d = serde_json::Map::new();
 
     if let Some(n) = name {
-        d.insert("name".to_string(), serde_json::Value::String(n.to_string()));
+        d.insert("name".to_string(), serde_json::Value::String(n.to_lowercase()));
     }
     if let Some(desc) = description {
         d.insert(

--- a/crates/spool/tests/state_tests.rs
+++ b/crates/spool/tests/state_tests.rs
@@ -532,7 +532,7 @@ fn test_state_materialization_create_stream() {
     assert_eq!(state.streams.len(), 1);
     let stream = state.streams.get("stream-001").unwrap();
     assert_eq!(stream.id, "stream-001");
-    assert_eq!(stream.name, "Project Alpha");
+    assert_eq!(stream.name, "project alpha");
     assert_eq!(stream.description.as_deref(), Some("Main project"));
     assert_eq!(stream.created_by, "@tester");
 }
@@ -561,8 +561,46 @@ fn test_state_materialization_update_stream() {
     let state = spool::state::materialize(&ctx).unwrap();
 
     let stream = state.streams.get("stream-002").unwrap();
-    assert_eq!(stream.name, "Updated Name");
+    assert_eq!(stream.name, "updated name");
     assert_eq!(stream.description.as_deref(), Some("New description"));
+}
+
+#[test]
+fn test_state_materialization_stream_name_normalization() {
+    // Test that stream names are normalized to lowercase during replay.
+    // This ensures existing mixed-case names in the event log are normalized.
+    let temp_dir = TempDir::new().unwrap();
+    let spool_dir = setup_spool_dir(&temp_dir);
+
+    let events = vec![
+        json!({
+            "v": 1, "op": "create_stream", "id": "stream-mixed",
+            "ts": "2024-01-15T10:00:00Z", "by": "@tester", "branch": "main",
+            "d": {"name": "My-Project-NAME"}
+        }),
+        json!({
+            "v": 1, "op": "create_stream", "id": "stream-upper",
+            "ts": "2024-01-15T10:01:00Z", "by": "@tester", "branch": "main",
+            "d": {"name": "UPPERCASE"}
+        }),
+        json!({
+            "v": 1, "op": "update_stream", "id": "stream-mixed",
+            "ts": "2024-01-15T11:00:00Z", "by": "@tester", "branch": "main",
+            "d": {"name": "Updated-NAME"}
+        }),
+    ];
+
+    write_events(&spool_dir.join("events"), "2024-01-15.jsonl", &events);
+
+    let ctx = create_test_context(&spool_dir);
+    let state = spool::state::materialize(&ctx).unwrap();
+
+    // Both streams should have lowercase names
+    let mixed = state.streams.get("stream-mixed").unwrap();
+    assert_eq!(mixed.name, "updated-name");
+
+    let upper = state.streams.get("stream-upper").unwrap();
+    assert_eq!(upper.name, "uppercase");
 }
 
 #[test]

--- a/crates/spool/tests/writer_tests.rs
+++ b/crates/spool/tests/writer_tests.rs
@@ -483,7 +483,7 @@ fn test_create_stream_returns_id() {
 
     assert_eq!(event["op"], "create_stream");
     assert_eq!(event["id"], id);
-    assert_eq!(event["d"]["name"], "My Project");
+    assert_eq!(event["d"]["name"], "my project");
 }
 
 #[test]
@@ -507,7 +507,7 @@ fn test_create_stream_with_description() {
 
     assert_eq!(event["op"], "create_stream");
     assert_eq!(event["id"], id);
-    assert_eq!(event["d"]["name"], "Backend");
+    assert_eq!(event["d"]["name"], "backend");
     assert_eq!(event["d"]["description"], "Backend development tasks");
 }
 
@@ -539,7 +539,7 @@ fn test_update_stream_writes_event() {
     let update_event: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
     assert_eq!(update_event["op"], "update_stream");
     assert_eq!(update_event["id"], id);
-    assert_eq!(update_event["d"]["name"], "New Name");
+    assert_eq!(update_event["d"]["name"], "new name");
     assert_eq!(update_event["d"]["description"], "Updated description");
 }
 


### PR DESCRIPTION
## Summary

- Normalize stream names to lowercase at write time in `create_stream()` and `update_stream()`
- Normalize names during event replay in `materialize()` to handle existing mixed-case entries
- Fix lookup inconsistency: `stream show --name` now uses case-insensitive comparison like `list --stream-name` already did
- Add test for stream name normalization behavior

## Test plan

- [x] All 263 workspace tests pass
- [x] Added `test_state_materialization_stream_name_normalization` to verify normalization
- [x] Verified `cargo clippy --workspace` reports no issues

## Breaking change note

This is a minor breaking change: existing mixed-case stream names in event logs will be silently normalized to lowercase on the next state rebuild. Per issue discussion, this is the preferred approach ("rip the bandaid off").

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)